### PR TITLE
feat: add last login time after login

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -4,3 +4,10 @@ exports.decodeBase64Url = str => (
     .replace(/_/g, '/')
     .replace(/\./g, '=')
 )
+
+exports.omit = (obj, keys) => Object.keys(obj).reduce((index, key) => {
+  if (keys.indexOf(key) === -1) {
+    index[key] = obj[key]
+  }
+  return index
+}, {})


### PR DESCRIPTION
Updates the user object with a last login datetime.

BREAKING CHANGES:
- `sessionService.putUser` is required (pouchdb-authentication v0.5.0)
- `_id` and `_rev` are replaced by `id` and `rev` in the returned session object
- All other reserved user properties (`password`, `salt` etc.) are removed

Closes #9.
