### PR TITLE
fix: validate session with remote

### DIFF
--- a/src/login.service.js
+++ b/src/login.service.js
@@ -98,10 +98,13 @@ class LoginService {
       if (!remote.ok) {
         return Promise.reject('session invalid')
       }
-      if (!remote.userCtx) {
-        return Promise.reject('missing user context in session')
+      if (!(remote.userCtx && remote.userCtx.name)) {
+        return Promise.reject('missing user context in remote session')
       }
-      if (remote.userCtx.name !== local.userName) {
+      if (!local.userName) {
+        return Promise.reject('missing user name in local session')
+      }
+      if (remote.userCtx.name.toLowerCase() !== local.userName.toLowerCase()) {
         return Promise.reject(`session mismatch for user ${local.userName}`)
       }
     }

--- a/src/login.service.js
+++ b/src/login.service.js
@@ -111,7 +111,7 @@ class LoginService {
         .then(remoteSession => isValidSession(localSession, remoteSession))
         .then(() => this.init(localSession))
         .catch(err => {
-          if ('status' in err && err.status === 0) {
+          if (angular.isObject(err) && err.status === 0) {
             // User looks to be offline, grant login
             return this.init(localSession)
           }


### PR DESCRIPTION
Before, we did not check whether the local session was still valid with the
remote, which lead to 401 errors.

Now validate the session and only grant offline login if we know so.

Note, we may still see 401 errors when the user comes back online if the session
has expired in the meantime. Consumers should call `canActivate` after verifying
the user has come back online and act accordingly.

Closes #11.
