### PR TITLE
fix: use navigator online to grant offline login

### DIFF
--- a/src/login.service.js
+++ b/src/login.service.js
@@ -114,7 +114,7 @@ class LoginService {
         .then(remoteSession => isValidSession(localSession, remoteSession))
         .then(() => this.init(localSession))
         .catch(err => {
-          if (angular.isObject(err) && err.status === 0) {
+          if (!this.$window.navigator.onLine) {
             // User looks to be offline, grant login
             return this.init(localSession)
           }


### PR DESCRIPTION
Sometimes seeing different response statuses here (e.g. 500, though I'm not sure
why). Revert to using naive `navigator.onLine` instead for offline login.

Closes #13.
