### PR TITLE
feat: modularise session CRU(D)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,10 @@ import angular from 'angular'
 
 import Login from './login.component'
 import LoginService from './login.service'
+import UserSessionService from './user-session.service'
 
 angular
   .module('angularNavLogin', [])
   .service('loginService', LoginService)
+  .service('userSessionService', UserSessionService)
   .component('login', Login)

--- a/src/user-session.service.js
+++ b/src/user-session.service.js
@@ -1,0 +1,60 @@
+import { omit } from './utils'
+
+const reservedUserProperties = [
+  '_id',
+  '_rev',
+  'name',
+  'password',
+  'roles',
+  'type',
+  'salt',
+  'derived_key',
+  'password_scheme',
+  'iterations'
+]
+
+class UserSessionService {
+  constructor (
+    sessionService
+  ) {
+    this.sessionService = sessionService
+  }
+
+  updateRemoteSession (username, session, diff) {
+    const omitted = omit(session, reservedUserProperties)
+    const metadata = Object.assign(omitted, diff)
+
+    const updateIdRev = res => {
+      if (!res.ok) {
+        return session
+      }
+      return Object.assign(metadata, omit(res, ['ok']))
+    }
+
+    const opts = {
+      metadata
+    }
+    return this.sessionService.putUser(username, opts)
+      .then(updateIdRev)
+  }
+
+  getSession () {
+    return this.sessionService.get('_local/session')
+  }
+
+  setSession (session) {
+    const doc = Object.assign({}, session, {
+      _id: '_local/session'
+    })
+    const opts = {
+      forceUpdate: true
+    }
+    return this.sessionService.save(doc, opts)
+  }
+}
+
+UserSessionService.$inject = [
+  'sessionService'
+]
+
+export default UserSessionService


### PR DESCRIPTION
As `loginService` depends on other services that are used within the app, we
often run into circular dependencies. Split the needed methods out into a new
service.

Closes #15.
