### PR TITLE
feat: remove redirect to '/Nav' on successful login

### DIFF
--- a/src/login.service.js
+++ b/src/login.service.js
@@ -4,7 +4,6 @@ class LoginService {
   constructor (
     $http,
     $window,
-    $rootRouter,
     config,
     sessionService,
     toastService,
@@ -13,7 +12,6 @@ class LoginService {
   ) {
     this.$http = $http
     this.$window = $window
-    this.$rootRouter = $rootRouter
     this.config = config
     this.sessionService = sessionService
     this.toastService = toastService
@@ -44,7 +42,6 @@ class LoginService {
 
   init (session) {
     this.mainService.init(session)
-    this.$rootRouter.navigate(['/Nav'])
     return session
   }
 


### PR DESCRIPTION
BREAKING CHANGE: this should be done in mainservice.init instead

this is for this change https://github.com/fielded/nav-integrated-state-dashboard/commit/44d09fb752d19048d07b6ffea121aaee89a82b80#diff-fb7316a4ae49d04b95801fa107d21facR63

thats related to this issue: https://github.com/fielded/van-orga/issues/434